### PR TITLE
Removed escaping when converting from silex

### DIFF
--- a/src/Controller/ArticlesController.php
+++ b/src/Controller/ArticlesController.php
@@ -50,8 +50,7 @@ class ArticlesController extends AbstractController
             "s.ho" => "t"
           ));
           $response_data = array(
-//            'query' => $this->escape($query),
-            'query' => $query,
+            'query' => htmlspecialchars($query),
             'number' => $summon_data->hits,
             'more' => $summon_full_search_link->getLink(),
             'records' => $summon_data->getBriefResults(),
@@ -83,7 +82,7 @@ class ArticlesController extends AbstractController
             )
           );
           $response_data = array(
-            'query' => $query,
+            'query' => htmlspecialchars($query),
             'number' => $summon_data->hits,
             'more' => $summon_full_search_link->getLink(),
             'records' => $summon_data->getBriefResults(),

--- a/src/Controller/FaqController.php
+++ b/src/Controller/FaqController.php
@@ -17,30 +17,30 @@ class FaqController extends AbstractController
         $num_records_brief_display = 3;
     
 
-        $query = $index_type;
+        $query = htmlspecialchars($index_type);
         $qString = array();
         if($request->query->get('group_id')) {
-          $qString['group_id'] = $request->query->get('group_id');
+          $qString['group_id'] = htmlspecialchars($request->query->get('group_id'));
         }
     
         if($request->query->get('topics')) {
-          $qString['topics'] = $request->query->get('topics');
+          $qString['topics'] = htmlspecialchars($request->query->get('topics'));
         }
     
         if($request->query->get('sort')) {
-          $qString['sort'] = $request->query->get('sort');
+          $qString['sort'] = htmlspecialchars($request->query->get('sort'));
         }
     
         if($request->query->get('sort_dir')) {
-          $qString['sort_dir'] = $request->query->get('sort_dir');
+          $qString['sort_dir'] = htmlspecialchars($request->query->get('sort_dir'));
         }
     
         if($request->query->get('page')) {
-          $qString['page'] = $request->query->get('page');
+          $qString['page'] = htmlspecialchars($request->query->get('page'));
         }
     
         if($request->query->get('callback')) {
-          $qString['callback'] = $request->query->get('callback');
+          $qString['callback'] = htmlspecialchars($request->query->get('callback'));
         }
     
         if($request->query->get('limit')) {

--- a/src/Controller/GuidesController.php
+++ b/src/Controller/GuidesController.php
@@ -30,7 +30,7 @@ class GuidesController extends AbstractController
         if (empty($request->query->get('query'))) {
             return "No Query Supplied";
         }
-        $query = $request->query->get('query');
+        $query = htmlspecialchars($request->query->get('query'));
 
         if($request->server->get('HTTP_REFERER')) { //should not be repeated moved out to utilities class
           $referer = $request->server->get('HTTP_REFERER');

--- a/src/Controller/PudlController.php
+++ b/src/Controller/PudlController.php
@@ -20,7 +20,7 @@ class PudlController extends AbstractController
         if (empty($request->query->get('query'))) {
             return "No Query Supplied";
         }
-        $query = $request->query->get('query');
+        $query = htmlspecialchars($request->query->get('query'));
 
         if($request->server->get('HTTP_REFERER')) { //should not be repeated moved out to utilities class
           $referer = $request->server->get('HTTP_REFERER');

--- a/src/Controller/PulfaController.php
+++ b/src/Controller/PulfaController.php
@@ -20,7 +20,7 @@ class PulfaController extends AbstractController
         if (empty($request->query->get('query'))) {
             return "No Query Supplied";
         }
-        $query = $request->query->get('query');
+        $query = htmlspecialchars($request->query->get('query'));
 
         if($request->server->get('HTTP_REFERER')) { //should not be repeated moved out to utilities class
           $referer = $request->server->get('HTTP_REFERER');


### PR DESCRIPTION
This commit adds the escaping back in, which I removed when converting from silex, since it was a  method.

The original code had `$app->escape($query)`.  I had trouble finding the escape method in Symfony. After further review I found that this was just a shortcut for `htmlspecialchars($query)`