### PR TITLE
Linking the .env file in the release directory

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -43,7 +43,7 @@ set :tmp_dir, '/home/deploy/tmp'
 desc "Report Uptimes"
 task :link_env do
   on roles(:app) do |host|
-    execute "cd #{deploy_to} && ln -sf /home/deploy/.env.local .env.local"
+    execute "cd #{release_path} && ln -sf /home/deploy/.env.local .env.local"
     info "linked .env.local"
   end
 end


### PR DESCRIPTION
It was mistakenly being linked in the directory above, which was causing an error with the articles search