### PR TITLE
set a default type so the library search does not bomb

### DIFF
--- a/classes/Blacklight/DpulResponse.php
+++ b/classes/Blacklight/DpulResponse.php
@@ -37,6 +37,8 @@ class DpulResponse
       }
       if (isset($record["attributes"]["readonly_format_ssim"])) {
         $parsed_record["type"] = array($record["attributes"]["readonly_format_ssim"]["attributes"]["value"]);
+      } else {
+        $parsed_record["type"] = array("Other");
       }
       $parsed_record["id"] = $record["id"];
       $parsed_record["url"] = $base_url .  $record["id"];


### PR DESCRIPTION
type[0] is needed in the code in the main library website
fixes #208