### PR TITLE
Copy .env.local instead of symlink for jammy. Push lando to php 8.1.

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -4,7 +4,7 @@ env_file:
   - defaults.env
 config:
   webroot: ./public
-  php: '8.0'
+  php: '8.1'
   composer_version: '2.4.1'
 services:
   appserver:

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -45,8 +45,8 @@ set :tmp_dir, '/home/deploy/tmp'
 desc "Link in local environment"
 task :link_env do
   on roles(:app) do |host|
-    execute "cd #{release_path} && ln -sf /home/deploy/.env.local .env.local"
-    info "linked .env.local"
+    execute "cd #{release_path} && cp /home/deploy/.env.local .env.local"
+    info "copied .env.local"
   end
 end
 after :deploy, :link_env


### PR DESCRIPTION
Deployed to staging. 